### PR TITLE
ch25036/allow linking to ticket automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.4.0 (October 29, 2020)
+## 1.4.0 (November 8, 2020)
 
 Add `ticketLink` input for automatically linking to tickets using `(?<ticketNumber>)` group in `titleRegex`, `branchRegex` and `bodyRegex`.
+Make `bodyURLRegex` optional and remove default.
 
 ## 1.3.3 (September 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0 (October 29, 2020)
+
+Add `ticketLink` input for automatically linking to tickets using `(?<ticketNumber>)` group in `titleRegex`, `branchRegex` and `bodyRegex`.
+
 ## 1.3.3 (September 30, 2020)
 
 Make ticket prefix optional

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
           bodyRegex: '#(?<ticketNumber>\d+)'
-          bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/\d+'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/(?<ticketNumber>\d+)'
 ```
 
 ### Jira
@@ -78,7 +78,7 @@ jobs:
           titleRegex: '^PROJ-(?<ticketNumber>\d+)'
           branchRegex: '^PROJ-(?<ticketNumber>\d+)'
           bodyRegex: 'PROJ-(?<ticketNumber>\d+)'
-          bodyURLRegex: 'http(s?):\/\/(:org.atlassian.net)(\/browse)\/(PROJ\-)\d+'
+          bodyURLRegex: 'http(s?):\/\/(:org.atlassian.net)(\/browse)\/(PROJ\-)(?<ticketNumber>\d+)'
 ```
 
 ### Clubhouse
@@ -105,7 +105,7 @@ jobs:
           titleRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
           branchRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
           bodyRegex: '(CH)(-?)(?<ticketNumber>\d{3,})'
-          bodyURLRegex: 'http(s?):\/\/(app.clubhouse.io)(\/:org)(\/story)\/\d+'
+          bodyURLRegex: 'http(s?):\/\/(app.clubhouse.io)(\/:org)(\/story)\/(?<ticketNumber>\d+)'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
         uses: neofinancial/ticket-check-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
           ticketPrefix: '#'
           titleRegex: '^#(\d+)'
           branchRegex: '^(\d+)'
@@ -70,6 +71,7 @@ jobs:
         uses: neofinancial/ticket-check-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://:org.atlassian.net/browse/PROJ-%ticketNumber%'
           ticketPrefix: 'PROJ-'
           titleRegex: '^PROJ-(\d+)'
           branchRegex: '^PROJ-(\d+)'
@@ -96,6 +98,7 @@ jobs:
         uses: neofinancial/ticket-check-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://app.clubhouse.io/:org/story/%ticketNumber%'
           ticketPrefix: 'CH-'
           titleRegex: '^(CH)(-?)(\d{3,})'
           branchRegex: '^(CH)(-?)(\d{3,})'
@@ -107,18 +110,19 @@ jobs:
 
 ## Inputs
 
-| Name              | Required | Description                                                                                                                                          | default               |
-| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| token             | ✅       | The GitHub access token                                                                                                                              |                       |
-| ticketPrefix      |          | The unique identifier for the ticket/issue                                                                                                           |                       |
-| titleFormat       |          | The intended format the title should be set to if it doesn't match the regular expression. Available variables are `%prefix%`, `%id%`, and `%title%` | %prefix%%id%: %title% |
-| titleRegex        |          | The regular expression used to search the title for the intended format                                                                              | ^(CH)(-?)(\d{3,})     |
-| titleRegexFlags   |          | The regular expression flags applied to the title regular expression                                                                                 | gi                    |
-| branchRegex       |          | The regular expression used to search the branch for the intended format                                                                             | ^(CH)(-?)(\d{3,})     |
-| branchRegexFlags  |          | The regular expression flags applied to the branch regular expression                                                                                | gi                    |
-| bodyRegex         |          | The regular expression used to search the body for a shorthand reference (example `#123`)                                                            | (CH)(-?)(\d{3,})      |
-| bodyRegexFlags    |          | The flags applied to the body regular expression when searching for a shorthand reference                                                            | gim                   |
-| bodyURLRegex      |          | The regular expression used to search the body for a URL reference (example `https://github.com/octocat/hello-world/issues/1`)                       |                       |
-| bodyURLRegexFlags |          | The flags applied to the body regular expression when searching for a URL reference                                                                  | gim                   |
-| exemptUsers       |          | Comma separated string of usernames that will be exempt from all checks. Most useful for bot/automated PRs (example "octocat,dependabot")            |                       |
-| quiet             |          | If `true`, don't comment when a PR title is updated                                                                                                  | true                  |
+| Name              | Required | Description                                                                                                                                          | default                          |
+| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| token             | ✅       | The GitHub access token                                                                                                                              |                                  |
+| ticketLink        |          | The URL format for a link to a ticket with a `%ticketNumber%` placeholder                                                                            |                                  |
+| ticketPrefix      |          | The unique identifier for the ticket/issue                                                                                                           |                                  |
+| titleFormat       |          | The intended format the title should be set to if it doesn't match the regular expression. Available variables are `%prefix%`, `%id%`, and `%title%` | %prefix%%id%: %title%            |
+| titleRegex        |          | The regular expression used to search the title for the intended format                                                                              | ^(CH)(-?)(?<ticketNumber>\d{3,}) |
+| titleRegexFlags   |          | The regular expression flags applied to the title regular expression                                                                                 | gi                               |
+| branchRegex       |          | The regular expression used to search the branch for the intended format                                                                             | ^(CH)(-?)(?<ticketNumber>\d{3,}) |
+| branchRegexFlags  |          | The regular expression flags applied to the branch regular expression                                                                                | gi                               |
+| bodyRegex         |          | The regular expression used to search the body for a shorthand reference (example `#123`)                                                            | (CH)(-?)(?<ticketNumber>\d{3,})  |
+| bodyRegexFlags    |          | The flags applied to the body regular expression when searching for a shorthand reference                                                            | gim                              |
+| bodyURLRegex      |          | The regular expression used to search the body for a URL reference (example `https://github.com/octocat/hello-world/issues/1`)                       |                                  |
+| bodyURLRegexFlags |          | The flags applied to the body regular expression when searching for a URL reference                                                                  | gim                              |
+| exemptUsers       |          | Comma separated string of usernames that will be exempt from all checks. Most useful for bot/automated PRs (example "octocat,dependabot")            |                                  |
+| quiet             |          | If `true`, don't comment when a PR title is updated                                                                                                  | true                             |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It can detect the ID in the title of the pull request, in the branch name, wheth
 
 If no ticket/issue ID is in the title, it will extract the ID from the branch or body and update the title for you. It will fail the check if no ticket ID is found anywhere.
 
+If a `ticketLink` input is provided and named groups `(?<ticketNumber>)` are used in regexes, a ticket link will be posted on a PR upon a successful match. This overrides the `quiet` option.
+
 ## Usage
 
 In your `.github/workflows` folder, create a new `pull_request_linting.yml` file with the respective contents based on your needs.
@@ -46,9 +48,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
           ticketPrefix: '#'
-          titleRegex: '^#(\d+)'
-          branchRegex: '^(\d+)'
-          bodyRegex: '#(\d+)'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          branchRegex: '^(?<ticketNumber>\d+)'
+          bodyRegex: '#(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/\d+'
 ```
 
@@ -73,9 +75,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://:org.atlassian.net/browse/PROJ-%ticketNumber%'
           ticketPrefix: 'PROJ-'
-          titleRegex: '^PROJ-(\d+)'
-          branchRegex: '^PROJ-(\d+)'
-          bodyRegex: 'PROJ-(\d+)'
+          titleRegex: '^PROJ-(?<ticketNumber>\d+)'
+          branchRegex: '^PROJ-(?<ticketNumber>\d+)'
+          bodyRegex: 'PROJ-(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(:org.atlassian.net)(\/browse)\/(PROJ\-)\d+'
 ```
 
@@ -100,9 +102,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://app.clubhouse.io/:org/story/%ticketNumber%'
           ticketPrefix: 'CH-'
-          titleRegex: '^(CH)(-?)(\d{3,})'
-          branchRegex: '^(CH)(-?)(\d{3,})'
-          bodyRegex: '(CH)(-?)(\d{3,})'
+          titleRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
+          branchRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
+          bodyRegex: '(CH)(-?)(?<ticketNumber>\d{3,})'
           bodyURLRegex: 'http(s?):\/\/(app.clubhouse.io)(\/:org)(\/story)\/\d+'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,6 @@ inputs:
 
   ticketLink:
     description: 'Ticket URL with `%ticketNumber%` placeholder'
-    default: 'https://app.clubhouse.io/neofinancial/story/%ticketNumber%'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
 
   titleRegex:
     description: 'The regular expression used to search the title for the intended format'
-    default: '^(CH)(-?)(\d{3,})'
+    default: '^(CH)(-?)(?<ticketNumber>\d{3,})'
     required: true
 
   titleRegexFlags:
@@ -25,7 +25,7 @@ inputs:
 
   branchRegex:
     description: 'The regular expression used to search the branch for the intended format'
-    default: '^(CH)(-?)(\d{3,})'
+    default: '^(CH)(-?)(?<ticketNumber>\d{3,})'
     required: true
 
   branchRegexFlags:
@@ -35,7 +35,7 @@ inputs:
 
   bodyRegex:
     description: 'The regular expression used to search the body for a shorthand reference'
-    default: '(CH)(-?)(\d{3,})'
+    default: '(CH)(-?)(?<ticketNumber>\d{3,})'
     required: true
 
   bodyRegexFlags:
@@ -66,6 +66,11 @@ inputs:
   token:
     description: 'GitHub authentication token'
     required: true
+
+  ticketLink:
+    description: 'Ticket URL with `%ticketNumber%` placeholder'
+    default: 'https://app.clubhouse.io/neofinancial/story/%ticketNumber%'
+    required: false
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,7 @@ inputs:
 
   bodyURLRegex:
     description: 'The regular expression used to search the body for a URL reference'
-    default: 'http(s?):\/\/(app.clubhouse.io)(\/neofinancial)(\/story)\/(?<ticketNumber>\d+)'
-    required: true
+    required: false
 
   bodyURLRegexFlags:
     description: 'The flags applied to the body regular expression when searching for a URL reference'

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
 
   bodyURLRegex:
     description: 'The regular expression used to search the body for a URL reference'
-    default: 'http(s?):\/\/(app.clubhouse.io)(\/neofinancial)(\/story)\/\d+'
+    default: 'http(s?):\/\/(app.clubhouse.io)(\/neofinancial)(\/story)\/(?<ticketNumber>\d+)'
     required: true
 
   bodyURLRegexFlags:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ticket-check-action",
   "description": "Verify that your pull request titles start with a ticket ID",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
   },
   "devDependencies": {
     "@actions/core": "1.2.6",
-    "@actions/github": "2.1.1",
+    "@actions/github": "4.0.0",
     "@types/node": "13.11.0",
-    "@zeit/ncc": "0.22.0",
+    "@vercel/ncc": "0.25.1",
     "eslint": "6.8.0",
     "eslint-config-neo": "0.5.2",
     "husky": "^4.2.3",
+    "is-plain-object": "^5.0.0",
     "lint-staged": "^10.1.1",
     "prettier": "1.19.1",
     "typescript": "3.8.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,15 @@ async function run(): Promise<void> {
     }
 
     // Last ditch effort, check for a ticket reference URL in the body
-    const bodyURLRegexBase = getInput('bodyURLRegex', { required: true });
+    const bodyURLRegexBase = getInput('bodyURLRegex', { required: false });
+
+    if (!bodyURLRegexBase) {
+      debug('failure', 'Title, branch, and body do not contain a reference to a ticket, and no body URL regex was set');
+      setFailed('No ticket was referenced in this pull request');
+
+      return;
+    }
+
     const bodyURLRegexFlags = getInput('bodyURLRegexFlags', {
       required: true
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,7 @@ async function run(): Promise<void> {
         return;
       }
 
-      const ticketLinkBody = `See the [ticket for this pull request](${ticketLink.replace(
-        '%ticketNumber%',
-        ticketNumber
-      )}).`;
+      const linkToTicket = ticketLink.replace('%ticketNumber%', ticketNumber);
 
       const currentReviews = await client.pulls.listReviews({
         owner,
@@ -77,7 +74,12 @@ async function run(): Promise<void> {
         pull_number: number
       });
 
-      if (currentReviews?.length && currentReviews.some((review: any) => review?.body === ticketLinkBody)) {
+      debug('current reviews', JSON.stringify(currentReviews));
+
+      if (
+        currentReviews?.data?.length &&
+        currentReviews?.data.some((review: { body?: string }) => review?.body?.includes(linkToTicket))
+      ) {
         debug('already posted ticketLink', 'found an existing review that contains the ticket link');
 
         return;
@@ -87,7 +89,7 @@ async function run(): Promise<void> {
         owner,
         repo,
         pull_number: number,
-        body: ticketLinkBody,
+        body: `See the ticket for this pull request: ${linkToTicket}`,
         event: 'COMMENT'
       });
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,19 +7,20 @@
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
   integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
 
-"@actions/github@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@actions/github/-/github-2.1.1.tgz#bcabedff598196d953f58ba750d5e75549a75142"
-  integrity sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==
+"@actions/github@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-4.0.0.tgz#d520483151a2bf5d2dc9cd0f20f9ac3a2e458816"
+  integrity sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==
   dependencies:
-    "@actions/http-client" "^1.0.3"
-    "@octokit/graphql" "^4.3.1"
-    "@octokit/rest" "^16.43.1"
+    "@actions/http-client" "^1.0.8"
+    "@octokit/core" "^3.0.0"
+    "@octokit/plugin-paginate-rest" "^2.2.3"
+    "@octokit/plugin-rest-endpoint-methods" "^4.0.0"
 
-"@actions/http-client@^1.0.3":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.8.tgz#8bd76e8eca89dc8bcf619aa128eba85f7a39af45"
-  integrity sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==
+"@actions/http-client@^1.0.8":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.9.tgz#af1947d020043dbc6a3b4c5918892095c30ffb52"
+  integrity sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==
   dependencies:
     tunnel "0.0.6"
 
@@ -59,6 +60,18 @@
   dependencies:
     "@octokit/types" "^2.0.0"
 
+"@octokit/core@^3.0.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.1.tgz#9e04df3f4e7f825ac0559327490ce34299140af5"
+  integrity sha512-XfFSDDwv6tclUenS0EmB6iA7u+4aOHBT1Lz4PtQNQQg3hBbNaR/+Uv5URU+egeIuuGAiMRiDyY92G4GBOWOqDA==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^5.0.0"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.0.tgz#4c7acd79ab72df78732a7d63b09be53ec5a2230b"
@@ -86,34 +99,20 @@
     "@octokit/types" "^2.0.0"
     universal-user-agent "^4.0.0"
 
-"@octokit/plugin-paginate-rest@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz#004170acf8c2be535aba26727867d692f7b488fc"
-  integrity sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==
+"@octokit/plugin-paginate-rest@^2.2.3":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.0.tgz#03416396e7a227b268c5b827365238f620a9c5c1"
+  integrity sha512-o+O8c1PqsC5++BHXfMZabRRsBIVb34tXPWyQLyp2IXq5MmkxdipS7TXM4Y9ldL1PzY9CTrCsn/lzFFJGM3oRRA==
   dependencies:
-    "@octokit/types" "^2.0.1"
+    "@octokit/types" "^5.5.0"
 
-"@octokit/plugin-request-log@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
-  integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
-
-"@octokit/plugin-rest-endpoint-methods@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz#3288ecf5481f68c494dd0602fc15407a59faf61e"
-  integrity sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==
+"@octokit/plugin-rest-endpoint-methods@^4.0.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.1.tgz#8224833a45c3394836dc6e86f1e6c49269a2c350"
+  integrity sha512-QyFr4Bv807Pt1DXZOC5a7L5aFdrwz71UHTYoHVajYV5hsqffWm8FUl9+O7nxRu5PDMtB/IKrhFqTmdBTK5cx+A==
   dependencies:
-    "@octokit/types" "^2.0.1"
+    "@octokit/types" "^5.5.0"
     deprecation "^2.3.1"
-
-"@octokit/request-error@^1.0.2":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.2.1.tgz#ede0714c773f32347576c25649dc013ae6b31801"
-  integrity sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==
-  dependencies:
-    "@octokit/types" "^2.0.0"
-    deprecation "^2.0.0"
-    once "^1.4.0"
 
 "@octokit/request-error@^2.0.0":
   version "2.0.0"
@@ -123,20 +122,6 @@
     "@octokit/types" "^2.0.0"
     deprecation "^2.0.0"
     once "^1.4.0"
-
-"@octokit/request@^5.2.0":
-  version "5.4.9"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.9.tgz#0a46f11b82351b3416d3157261ad9b1558c43365"
-  integrity sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==
-  dependencies:
-    "@octokit/endpoint" "^6.0.1"
-    "@octokit/request-error" "^2.0.0"
-    "@octokit/types" "^5.0.0"
-    deprecation "^2.0.0"
-    is-plain-object "^5.0.0"
-    node-fetch "^2.6.1"
-    once "^1.4.0"
-    universal-user-agent "^6.0.0"
 
 "@octokit/request@^5.3.0":
   version "5.3.4"
@@ -152,27 +137,19 @@
     once "^1.4.0"
     universal-user-agent "^5.0.0"
 
-"@octokit/rest@^16.43.1":
-  version "16.43.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.43.2.tgz#c53426f1e1d1044dee967023e3279c50993dd91b"
-  integrity sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==
+"@octokit/request@^5.4.0":
+  version "5.4.10"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.10.tgz#402d2c53768bde12b99348329ba4129746aebb9c"
+  integrity sha512-egA49HkqEORVGDZGav1mh+VD+7uLgOxtn5oODj6guJk0HCy+YBSYapFkSLFgeYj3Fr18ZULKGURkjyhkAChylw==
   dependencies:
-    "@octokit/auth-token" "^2.4.0"
-    "@octokit/plugin-paginate-rest" "^1.1.1"
-    "@octokit/plugin-request-log" "^1.0.0"
-    "@octokit/plugin-rest-endpoint-methods" "2.4.0"
-    "@octokit/request" "^5.2.0"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^2.0.0"
-    btoa-lite "^1.0.0"
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^5.0.0"
     deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
     once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    universal-user-agent "^6.0.0"
 
 "@octokit/types@^2.0.0":
   version "2.5.1"
@@ -181,14 +158,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^2.0.1":
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.16.2.tgz#4c5f8da3c6fecf3da1811aef678fda03edac35d2"
-  integrity sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==
-  dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^5.0.0":
+"@octokit/types@^5.0.0", "@octokit/types@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
   integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
@@ -268,10 +238,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@zeit/ncc@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.22.0.tgz#1a4132a375a2ffd1d6d632b0fdd9027154f6141a"
-  integrity sha512-zaS6chwztGSLSEzsTJw9sLTYxQt57bPFBtsYlVtbqGvmDUsfW7xgXPYofzFa1kB9ur2dRop6IxCwPnWLBVCrbQ==
+"@vercel/ncc@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.25.1.tgz#a4aacdb508ac496fc0c63a3c3203d700a619cc0e"
+  integrity sha512-dGecC5+1wLof1MQpey4+6i2KZv4Sfs6WfXkl9KfO32GED4ZPiKxRfvtGPjbjZv0IbqMl6CxtcV1RotXYfd5SSA==
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -372,17 +342,12 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-atob-lite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
-  integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-before-after-hook@^2.0.0:
+before-after-hook@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
@@ -401,11 +366,6 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-btoa-lite@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
-  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -1493,11 +1453,6 @@ lodash.kebabcase@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
   integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.snakecase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
@@ -1507,11 +1462,6 @@ lodash.topairs@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.topairs/-/lodash.topairs-4.3.0.tgz#3b6deaa37d60fb116713c46c5f17ea190ec48d64"
   integrity sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash.upperfirst@^4.3.1:
   version "4.3.1"
@@ -1712,11 +1662,6 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-octokit-pagination-methods@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
-  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
When the inputs include a `ticketLink`, the check action will post a comment containing a link to the ticket using the input and replacing `%ticketNumber%` with the ticketNumber named group from title/branch/body regexes. (It doesn't do this on a bodyUrlRegex match because the ticket is already linked in the PR body)
This is required on a few PR templates and I resent doing it manually. :smile: 

e.g. ticketLink = `www.example.com/ticket/%ticketNumber%`
branch name `ticket123` is matched with branch regex `/(ticket)(?<ticketNumber>\d+)/`
action posts review comment with link `www.example.com/ticket/123`