### PR TITLE
Updates README to support Shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://app.shortcut.com/:org/story/%ticketNumber%'
-          ticketPrefix: 'sc-'
+          ticketPrefix: 'SC-'
           titleRegex: '^(CH|sc)(-?)(\d+)\/.+'
           bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
           branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
-          bodyURLRegex: 'https?:\/\/(app\.(clubhouse|shortcut)\.(io|com))\/neofinancial\/story\/(?<ticketNumber>\d+)\/.+'
+          bodyURLRegex: 'https?:\/\/app\.(clubhouse.io|shortcut.com)(\/:org)\/story\/(?<ticketNumber>\d+)\/.+'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
           bodyURLRegex: 'http(s?):\/\/(:org.atlassian.net)(\/browse)\/(PROJ\-)(?<ticketNumber>\d+)'
 ```
 
-### Shortcut (former Clubhouse)
+### Shortcut (formerly Clubhouse)
 
 ```yml
 name: Pull Request Lint

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
           bodyURLRegex: 'http(s?):\/\/(:org.atlassian.net)(\/browse)\/(PROJ\-)(?<ticketNumber>\d+)'
 ```
 
-### Clubhouse
+### Shortcut (former Clubhouse)
 
 ```yml
 name: Pull Request Lint
@@ -100,12 +100,12 @@ jobs:
         uses: neofinancial/ticket-check-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ticketLink: 'https://app.clubhouse.io/:org/story/%ticketNumber%'
-          ticketPrefix: 'CH-'
-          titleRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
-          branchRegex: '^(CH)(-?)(?<ticketNumber>\d{3,})'
-          bodyRegex: '(CH)(-?)(?<ticketNumber>\d{3,})'
-          bodyURLRegex: 'http(s?):\/\/(app.clubhouse.io)(\/:org)(\/story)\/(?<ticketNumber>\d+)'
+          ticketLink: 'https://app.shortcut.com/:org/story/%ticketNumber%'
+          ticketPrefix: 'sc-'
+          titleRegex: '^(CH|sc)(-?)(\d+)\/.+'
+          bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
+          branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
+          bodyURLRegex: 'https?:\/\/(app\.(clubhouse|shortcut)\.(io|com))\/neofinancial\/story\/(?<ticketNumber>\d+)\/.+'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://app.shortcut.com/:org/story/%ticketNumber%'
           ticketPrefix: 'SC-'
-          titleRegex: '^(CH|sc)(-?)(\d+)\/.+'
-          bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
-          branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)\/.+'
+          titleRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+):'
+          branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+):'
+          bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+):'
           bodyURLRegex: 'https?:\/\/app\.(clubhouse.io|shortcut.com)(\/:org)\/story\/(?<ticketNumber>\d+)\/.+'
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://app.shortcut.com/:org/story/%ticketNumber%'
           ticketPrefix: 'SC-'
-          titleRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+):'
-          branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+):'
-          bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+):'
+          titleRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)'
+          branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)'
+          bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+)'
           bodyURLRegex: 'https?:\/\/app\.(clubhouse.io|shortcut.com)(\/:org)\/story\/(?<ticketNumber>\d+)\/.+'
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ jobs:
           titleRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)'
           branchRegex: '^(CH|sc)(-?)(?<ticketNumber>\d+)'
           bodyRegex: '(CH|sc)(-?)(?<ticketNumber>\d+)'
-          bodyURLRegex: 'https?:\/\/app\.(clubhouse.io|shortcut.com)(\/:org)\/story\/(?<ticketNumber>\d+)\/.+'
+          bodyURLRegex: 'https?:\/\/app\.(clubhouse.io|shortcut.com)(\/:org)\/story\/(?<ticketNumber>\d+)'
 ```
 
 </details>


### PR DESCRIPTION
Updating some regex to support Shortcut (formerly known as Clubhouse). Kept some checks backwards compatible since we might have some branches that were created before and still have `CH` instead of `sc` in their structure.