### PR TITLE
Runs actions on eks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: neo-x86-medium
+    runs-on: neo-x86-small
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    runs-on: neo-x86-medium
+    runs-on: neo-x86-small
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -14,13 +14,13 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   release:
-    runs-on: neo-x86-medium
+    runs-on: neo-x86-small
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: npm


### PR DESCRIPTION
# What Has Changed?
We\'re moving away from GitHub hosted actions runners to running actions on our own Elastic Kubernetes Service (EKS) cluster.
The switch to an EKS environment enables us to manage our environment more effectively, gives us greater control over security measures, optimizes resource utilization, and importantly, ensures cost-efficiency. With EKS, we have the advantage of pricing based on our actual compute resource usage rather than the duration of operations.
This pull request moves all possible actions to run on EKS.